### PR TITLE
Initial implementation

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -31,6 +32,8 @@ var (
 	acmeReg    = flag.String("acmeReg", "", "path to the json user registration file for acme")
 
 	kubeClient *client.Client
+	acmeImpl   *acmeimpl.AcmeImpl
+	lockSvc    *locking.Locking
 )
 
 func main() {
@@ -54,116 +57,22 @@ func main() {
 		glog.Fatalf("error launching apiserver watcher: %s", err.Error())
 	}
 
-	key, err := ioutil.ReadFile(*acmeKey)
+	acmeImpl, err = initAcmeImpl()
 
 	if err != nil {
-		glog.Fatalf("failed reading private key: %s", err.Error())
+		glog.Fatalf("error initialising acmeimpl: %s", err.Error())
 	}
 
-	block, _ := pem.Decode(key)
-
-	privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	lockSvc, err = initKubeLockService(kubeClient)
 
 	if err != nil {
-		glog.Fatalf("error decoding private key: %s", err.Error())
-	}
-
-	regBytes, err := ioutil.ReadFile(*acmeReg)
-
-	if err != nil {
-		glog.Fatalf("error reading acme registration: %s", err.Error())
-	}
-
-	reg := new(acme.RegistrationResource)
-
-	err = json.Unmarshal(regBytes, reg)
-
-	if err != nil {
-		glog.Fatalf("error reading user registration: %s", err.Error())
-	}
-
-	impl, err := acmeimpl.NewAcmeImpl(kubeClient, *acmeServer, acmeimpl.NewUser(*acmeEmail, privKey, reg), acme.RSA2048)
-
-	if err != nil {
-		glog.Fatalf("error initialising acme: %s", err.Error())
-	}
-
-	kubeLockProvider, err := locking.NewKubeProvider(kubeClient)
-
-	if err != nil {
-		glog.Fatalf("error initialising kubernetes locking provider: %s", err.Error())
-	}
-
-	lockSvc, err := locking.New(kubeLockProvider)
-
-	if err != nil {
-		glog.Fatalf("error initialisng locker: %s", err.Error())
+		glog.Fatalf("error initialisng lock service: %s", err.Error())
 	}
 
 	ctx, _ := context.WithCancel(context.Background())
 
 	go w.WatchIngresses(ctx, time.Second*5, watcher.ChangeFuncs{
-		AddFunc: func(obj interface{}) {
-			if ing, ok := obj.(*extensions.Ingress); ok {
-				if val, ok := ing.Labels["acme-tls"]; !ok || val != "true" {
-					// only run on ingresses with acme-tls true
-					return
-				}
-				if len(ing.Spec.TLS) > 0 {
-					// TODO: if acme managed, check if certificates are valid
-					// TODO: check if certificates exist
-				TLSLoop:
-					for _, t := range ing.Spec.TLS {
-						locks := make([]locking.Interface, len(t.Hosts))
-						for i, host := range t.Hosts {
-							lock, err := locking.NewKubeLock(createSecretLock(host, "acme"))
-
-							if err != nil {
-								glog.Errorf("error creating lock for host '%s': %s", host, err.Error())
-								continue TLSLoop
-							}
-
-							locks[i] = lock
-						}
-
-						locks, errs := lockSvc.LockAll(locks...)
-
-						if len(errs) > 0 {
-							for _, err := range errs {
-								glog.Errorf("error acquiring locks: %s", err.Error())
-							}
-							continue TLSLoop
-						}
-
-						defer lockSvc.UnlockAll(locks...)
-
-						glog.Errorf("acquired all locks for resource: %s", ing.Name)
-
-						certs, acmeErrs := impl.ObtainCertificates(t.Hosts...)
-
-						if len(acmeErrs) > 0 {
-							for _, err := range acmeErrs {
-								glog.Errorf("failed retreiving certificates: %s", err.Error())
-							}
-							continue TLSLoop
-						}
-
-						secret := createSecret(t.SecretName, ing.Namespace, certs.Certificate, certs.PrivateKey)
-
-						secret, err = kubeClient.Secrets(ing.Namespace).Create(secret)
-
-						if err != nil {
-							glog.Errorf("error saving certificate to kubernetes: %s", err)
-							continue TLSLoop
-						}
-
-						glog.Errorf("Successfully saved secret %s", secret.Name)
-					}
-				}
-			} else {
-				glog.Errorf("Expected object of type Ingress")
-			}
-		},
+		AddFunc: addIngFunc,
 		UpdateFunc: func(old, cur interface{}) {
 			if !reflect.DeepEqual(old, cur) {
 				glog.Infof("Ingress %v changed",
@@ -176,6 +85,138 @@ func main() {
 	})
 
 	<-make(chan struct{})
+}
+
+func initAcmeImpl() (*acmeimpl.AcmeImpl, error) {
+	privKey, err := loadAcmePrivateKey(*acmeKey)
+
+	if err != nil {
+		glog.Fatalf("error loading acme private key: %s", err.Error())
+	}
+
+	reg, err := loadAcmeRegistration(*acmeReg)
+
+	if err != nil {
+		glog.Fatalf("error loading acme registration: %s", err.Error())
+	}
+
+	return acmeimpl.NewAcmeImpl(kubeClient, *acmeServer, acmeimpl.NewUser(*acmeEmail, privKey, reg), acme.RSA2048)
+
+}
+
+func initKubeLockService(client *client.Client) (*locking.Locking, error) {
+	klp, err := locking.NewKubeProvider(client)
+
+	if err != nil {
+		return nil, fmt.Errorf("error initialising kubernetes locking provider: %s", err.Error())
+	}
+
+	lockSvc, err := locking.New(klp)
+
+	if err != nil {
+		fmt.Errorf("error initialisng locker: %s", err.Error())
+	}
+
+	return lockSvc, nil
+}
+
+func loadAcmePrivateKey(file string) (*rsa.PrivateKey, error) {
+	key, err := ioutil.ReadFile(file)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed reading private key: %s", err.Error())
+	}
+
+	block, _ := pem.Decode(key)
+
+	privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+
+	if err != nil {
+		return nil, fmt.Errorf("error decoding private key: %s", err.Error())
+	}
+
+	return privKey, nil
+}
+
+func loadAcmeRegistration(file string) (*acme.RegistrationResource, error) {
+	regBytes, err := ioutil.ReadFile(file)
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading acme registration: %s", err.Error())
+	}
+
+	reg := new(acme.RegistrationResource)
+
+	err = json.Unmarshal(regBytes, reg)
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading user registration: %s", err.Error())
+	}
+
+	return reg, nil
+}
+
+func addIngFunc(obj interface{}) {
+	if ing, ok := obj.(*extensions.Ingress); ok {
+		if val, ok := ing.Labels["acme-tls"]; !ok || val != "true" {
+			// only run on ingresses with acme-tls true
+			return
+		}
+		if len(ing.Spec.TLS) > 0 {
+
+			// TODO: if acme managed, check if certificates are valid
+			// TODO: check if certificates exist
+		TLSLoop:
+			for _, t := range ing.Spec.TLS {
+				locks := make([]locking.Interface, len(t.Hosts))
+				for i, host := range t.Hosts {
+					lock, err := locking.NewKubeLock(createSecretLock(host, "acme"))
+
+					if err != nil {
+						glog.Errorf("error creating lock for host '%s': %s", host, err.Error())
+						continue TLSLoop
+					}
+
+					locks[i] = lock
+				}
+
+				locks, errs := lockSvc.LockAll(locks...)
+
+				if len(errs) > 0 {
+					for _, err := range errs {
+						glog.Errorf("error acquiring locks: %s", err.Error())
+					}
+					continue TLSLoop
+				}
+
+				defer lockSvc.UnlockAll(locks...)
+
+				glog.Errorf("acquired all locks for resource: %s", ing.Name)
+
+				certs, acmeErrs := acmeImpl.ObtainCertificates(t.Hosts...)
+
+				if len(acmeErrs) > 0 {
+					for _, err := range acmeErrs {
+						glog.Errorf("failed retreiving certificates: %s", err.Error())
+					}
+					continue TLSLoop
+				}
+
+				secret := createSecret(t.SecretName, ing.Namespace, certs.Certificate, certs.PrivateKey)
+
+				secret, err := kubeClient.Secrets(ing.Namespace).Create(secret)
+
+				if err != nil {
+					glog.Errorf("error saving certificate to kubernetes: %s", err)
+					continue TLSLoop
+				}
+
+				glog.Errorf("Successfully saved secret %s", secret.Name)
+			}
+		}
+	} else {
+		glog.Errorf("Expected object of type Ingress")
+	}
 }
 
 func createSecret(name, namespace string, cert, key []byte) *api.Secret {

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/golang/glog"
+	"github.com/munnerz/acme-secrets/pkg/acmeimpl"
+	"github.com/munnerz/acme-secrets/pkg/watcher"
+	"github.com/xenolf/lego/acme"
+)
+
+var (
+	proxyURL   = flag.String("proxyURL", "", "URL to proxy connections to the apiserver")
+	acmeServer = flag.String("acmeServer", "https://acme-staging.api.letsencrypt.org/directory", "the acme server to request certificates from")
+	acmeEmail  = flag.String("acmeEmail", "", "the user email address for the acme server")
+	acmeKey    = flag.String("acmeKey", "", "path to the file containing the users private key")
+	acmeReg    = flag.String("acmeReg", "", "path to the json user registration file for acme")
+
+	kubeClient *client.Client
+)
+
+func main() {
+	flag.Parse()
+
+	if *proxyURL != "" {
+		kubeClient = client.NewOrDie(&client.Config{
+			Host: *proxyURL,
+		})
+	} else {
+		var err error
+		kubeClient, err = client.NewInCluster()
+		if err != nil {
+			glog.Fatalf("Failed to create client: %v.", err)
+		}
+	}
+
+	w, err := watcher.New(kubeClient, "default")
+
+	if err != nil {
+		glog.Fatalf("error launching apiserver watcher: %s", err.Error())
+	}
+
+	key, err := ioutil.ReadFile(*acmeKey)
+
+	if err != nil {
+		glog.Fatalf("failed reading private key: %s", err.Error())
+	}
+
+	block, _ := pem.Decode(key)
+
+	privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+
+	if err != nil {
+		glog.Fatalf("error decoding private key: %s", err.Error())
+	}
+
+	regBytes, err := ioutil.ReadFile(*acmeReg)
+
+	if err != nil {
+		glog.Fatalf("error reading acme registration: %s", err.Error())
+	}
+
+	reg := new(acme.RegistrationResource)
+
+	err = json.Unmarshal(regBytes, reg)
+
+	if err != nil {
+		glog.Fatalf("error reading user registration: %s", err.Error())
+	}
+
+	impl, err := acmeimpl.NewAcmeImpl(kubeClient, *acmeServer, acmeimpl.NewUser(*acmeEmail, privKey, reg), acme.RSA2048)
+
+	if err != nil {
+		glog.Fatalf("error initialising acme: %s", err.Error())
+	}
+
+	ctx, _ := context.WithCancel(context.Background())
+
+	go w.WatchIngresses(ctx, time.Second*5, watcher.ChangeFuncs{
+		AddFunc: func(obj interface{}) {
+			if ing, ok := obj.(*extensions.Ingress); ok {
+				if val, ok := ing.Labels["acme-tls"]; !ok || val != "true" {
+					// only run on ingresses with acme-tls true
+					return
+				}
+				if len(ing.Spec.TLS) > 0 {
+					// TODO: if acme managed, check if certificates are valid
+					// TODO: check if certificates exist
+					for _, t := range ing.Spec.TLS {
+						locks, err := lock(t.Hosts...)
+
+						if err != nil {
+							glog.Errorf("error acquiring lock: %s", err.Error())
+							return
+						}
+
+						defer unlock(locks...)
+
+						glog.Errorf("acquired all locks for resource: %s", ing.Name)
+
+						certs, errs := impl.ObtainCertificates(t.Hosts...)
+
+						if len(errs) > 0 {
+							glog.Errorf("failed retreiving certificates: %s", errs)
+							return
+						}
+
+						glog.Errorf("Got certs: %s", certs)
+					}
+				}
+			} else {
+				glog.Errorf("Expected object of type Ingress")
+			}
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			if !reflect.DeepEqual(old, cur) {
+				glog.Infof("Ingress %v changed",
+					cur.(*extensions.Ingress).Name)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			glog.Errorf("Something deleted")
+		},
+	})
+
+	<-make(chan struct{})
+}
+
+type LockResource struct {
+	Secret *api.Secret
+	Expiry time.Time
+}
+
+func unlockSecrets(secrets ...*api.Secret) error {
+	wg := sync.WaitGroup{}
+	errc := make(chan error, len(secrets))
+	wg.Add(len(secrets))
+	for _, res := range secrets {
+		go func(lock *api.Secret) {
+			defer wg.Done()
+			err := releaseLock(res)
+
+			if err != nil {
+				glog.Errorf("Failed to release lock: %s", err.Error())
+				return
+			}
+		}(res)
+	}
+	wg.Wait()
+	close(errc)
+	for err := range errc {
+		return err
+	}
+	return nil
+}
+
+func unlock(locks ...*LockResource) error {
+	secrets := make([]*api.Secret, len(locks))
+	for i, l := range locks {
+		secrets[i] = l.Secret
+	}
+	return unlockSecrets(secrets...)
+}
+
+func lock(hosts ...string) ([]*LockResource, error) {
+	type result struct {
+		secret *api.Secret
+		expiry time.Time
+		err    error
+	}
+	lockc := make(chan *result, len(hosts))
+	wg := sync.WaitGroup{}
+	wg.Add(len(hosts))
+	for _, host := range hosts {
+		go func(host string) {
+			defer wg.Done()
+			secName := fmt.Sprintf("%s-acme", host)
+			lock, expiry, err := acquireLock(secName, "acme")
+			lockc <- &result{lock, expiry, err}
+		}(host)
+	}
+
+	wg.Wait()
+	close(lockc)
+	locks := make([]*LockResource, len(hosts))
+	i := 0
+	failed := false
+	for lock := range lockc {
+		if lock.err != nil {
+			glog.Errorf("Error whilst acquiring lock: %s", lock.err.Error())
+			failed = true
+		}
+		locks[i] = &LockResource{lock.secret, lock.expiry}
+		i++
+	}
+	if failed {
+		// TODO: add this ingress onto a queue to reprocess
+		err := unlock(locks...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to acquire lock, and failed to clean up after attempting to acquire")
+		}
+		return nil, fmt.Errorf("failed to acquire all locks")
+	}
+
+	return locks, nil
+}
+
+// acquireLock will acquire a lock by attempting to create a secret with name `name`
+// in the given namespace. If a lock with the same name already exists, it'll check
+// the locks expiry time and if it's less than the current time, will acquire the lock for
+// itself
+func acquireLock(name, namespace string) (*api.Secret, time.Time, error) {
+	var err error
+	expiry, secret := createSecretLock(name, namespace)
+	secret, err = kubeClient.Secrets(namespace).Create(secret)
+
+	if err != nil {
+		// another instance is likely dealing with this request
+		glog.Errorf("Error creating secret lock: %s", err.Error())
+		glog.Infof("Attempting cleanup of lock")
+
+		ex, err := kubeClient.Secrets(namespace).Get(name)
+
+		if err != nil {
+			return nil, time.Now(), fmt.Errorf("secret lock has already been deleted - another instance is cleaning up: %s", err.Error())
+		}
+
+		exp, err := strconv.ParseInt(ex.Labels["acme-expiry"], 10, 64)
+		if err != nil {
+			return nil, time.Now(), fmt.Errorf("invalid expiry format: %s", err.Error())
+		}
+
+		expiry := time.Unix(0, exp)
+
+		glog.Errorf("Expires: %s", expiry.String())
+		if time.Now().Before(expiry) {
+			return nil, time.Now(), fmt.Errorf("existing lock is still valid")
+		}
+
+		err = releaseLock(ex)
+
+		if err != nil {
+			return nil, time.Now(), fmt.Errorf("another instance has deleted the lock: %s", err.Error())
+		}
+
+		expiry, secret = createSecretLock(name, namespace)
+		secret, err = kubeClient.Secrets(namespace).Create(secret)
+
+		if err != nil {
+			return nil, time.Now(), fmt.Errorf("another instance has acquired the lock: %s", err.Error())
+		}
+	}
+
+	return secret, expiry, nil
+}
+
+func releaseLock(lock *api.Secret) error {
+	if _, ok := lock.Labels["acme-expiry"]; !ok {
+		return fmt.Errorf("missing acme-expiry label on lock")
+	}
+
+	requirement, err := labels.NewRequirement("acme-expiry", labels.EqualsOperator, sets.NewString(lock.Labels["acme-expiry"]))
+
+	if err != nil {
+		return err
+	}
+
+	return kubeClient.RESTClient.Delete().
+		Namespace(lock.Namespace).
+		Resource("secrets").
+		Name(lock.Name).
+		LabelsSelectorParam(labels.NewSelector().Add(*requirement)).
+		Do().
+		Error()
+}
+
+func createSecretLock(name string, namespace string) (time.Time, *api.Secret) {
+	expiry := time.Now().Add(time.Second * 30)
+	return expiry, &api.Secret{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"acme-managed": "true",
+				"acme-lock":    "true",
+				"acme-expiry":  fmt.Sprintf("%d", expiry.UnixNano()),
+			},
+		},
+	}
+}

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
-	"strconv"
-	"sync"
 	"time"
 
 	"golang.org/x/net/context"
@@ -17,11 +15,10 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/labels"
-	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 	"github.com/munnerz/acme-secrets/pkg/acmeimpl"
+	"github.com/munnerz/acme-secrets/pkg/locking"
 	"github.com/munnerz/acme-secrets/pkg/watcher"
 	"github.com/xenolf/lego/acme"
 )
@@ -91,6 +88,18 @@ func main() {
 		glog.Fatalf("error initialising acme: %s", err.Error())
 	}
 
+	kubeLockProvider, err := locking.NewKubeProvider(kubeClient)
+
+	if err != nil {
+		glog.Fatalf("error initialising kubernetes locking provider: %s", err.Error())
+	}
+
+	lockSvc, err := locking.New(kubeLockProvider)
+
+	if err != nil {
+		glog.Fatalf("error initialisng locker: %s", err.Error())
+	}
+
 	ctx, _ := context.WithCancel(context.Background())
 
 	go w.WatchIngresses(ctx, time.Second*5, watcher.ChangeFuncs{
@@ -103,23 +112,40 @@ func main() {
 				if len(ing.Spec.TLS) > 0 {
 					// TODO: if acme managed, check if certificates are valid
 					// TODO: check if certificates exist
+				TLSLoop:
 					for _, t := range ing.Spec.TLS {
-						locks, err := lock(t.Hosts...)
+						locks := make([]locking.Interface, len(t.Hosts))
+						for i, host := range t.Hosts {
+							lock, err := locking.NewKubeLock(createSecretLock(host, "acme"))
 
-						if err != nil {
-							glog.Errorf("error acquiring lock: %s", err.Error())
-							return
+							if err != nil {
+								glog.Errorf("error creating lock for host '%s': %s", host, err.Error())
+								continue TLSLoop
+							}
+
+							locks[i] = lock
 						}
 
-						defer unlock(locks...)
+						locks, errs := lockSvc.LockAll(locks...)
+
+						if len(errs) > 0 {
+							for _, err := range errs {
+								glog.Errorf("error acquiring locks: %s", err.Error())
+							}
+							continue TLSLoop
+						}
+
+						defer lockSvc.UnlockAll(locks...)
 
 						glog.Errorf("acquired all locks for resource: %s", ing.Name)
 
-						certs, errs := impl.ObtainCertificates(t.Hosts...)
+						certs, acmeErrs := impl.ObtainCertificates(t.Hosts...)
 
-						if len(errs) > 0 {
-							glog.Errorf("failed retreiving certificates: %s", errs)
-							return
+						if len(acmeErrs) > 0 {
+							for _, err := range acmeErrs {
+								glog.Errorf("failed retreiving certificates: %s", err.Error())
+							}
+							continue TLSLoop
 						}
 
 						glog.Errorf("Got certs: %s", certs)
@@ -143,168 +169,19 @@ func main() {
 	<-make(chan struct{})
 }
 
-type LockResource struct {
-	Secret *api.Secret
-	Expiry time.Time
-}
-
-func unlockSecrets(secrets ...*api.Secret) error {
-	wg := sync.WaitGroup{}
-	errc := make(chan error, len(secrets))
-	wg.Add(len(secrets))
-	for _, res := range secrets {
-		go func(lock *api.Secret) {
-			defer wg.Done()
-			err := releaseLock(res)
-
-			if err != nil {
-				glog.Errorf("Failed to release lock: %s", err.Error())
-				return
-			}
-		}(res)
-	}
-	wg.Wait()
-	close(errc)
-	for err := range errc {
-		return err
-	}
-	return nil
-}
-
-func unlock(locks ...*LockResource) error {
-	secrets := make([]*api.Secret, len(locks))
-	for i, l := range locks {
-		secrets[i] = l.Secret
-	}
-	return unlockSecrets(secrets...)
-}
-
-func lock(hosts ...string) ([]*LockResource, error) {
-	type result struct {
-		secret *api.Secret
-		expiry time.Time
-		err    error
-	}
-	lockc := make(chan *result, len(hosts))
-	wg := sync.WaitGroup{}
-	wg.Add(len(hosts))
-	for _, host := range hosts {
-		go func(host string) {
-			defer wg.Done()
-			secName := fmt.Sprintf("%s-acme", host)
-			lock, expiry, err := acquireLock(secName, "acme")
-			lockc <- &result{lock, expiry, err}
-		}(host)
-	}
-
-	wg.Wait()
-	close(lockc)
-	locks := make([]*LockResource, len(hosts))
-	i := 0
-	failed := false
-	for lock := range lockc {
-		if lock.err != nil {
-			glog.Errorf("Error whilst acquiring lock: %s", lock.err.Error())
-			failed = true
-		}
-		locks[i] = &LockResource{lock.secret, lock.expiry}
-		i++
-	}
-	if failed {
-		// TODO: add this ingress onto a queue to reprocess
-		err := unlock(locks...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to acquire lock, and failed to clean up after attempting to acquire")
-		}
-		return nil, fmt.Errorf("failed to acquire all locks")
-	}
-
-	return locks, nil
-}
-
-// acquireLock will acquire a lock by attempting to create a secret with name `name`
-// in the given namespace. If a lock with the same name already exists, it'll check
-// the locks expiry time and if it's less than the current time, will acquire the lock for
-// itself
-func acquireLock(name, namespace string) (*api.Secret, time.Time, error) {
-	var err error
-	expiry, secret := createSecretLock(name, namespace)
-	secret, err = kubeClient.Secrets(namespace).Create(secret)
-
-	if err != nil {
-		// another instance is likely dealing with this request
-		glog.Errorf("Error creating secret lock: %s", err.Error())
-		glog.Infof("Attempting cleanup of lock")
-
-		ex, err := kubeClient.Secrets(namespace).Get(name)
-
-		if err != nil {
-			return nil, time.Now(), fmt.Errorf("secret lock has already been deleted - another instance is cleaning up: %s", err.Error())
-		}
-
-		exp, err := strconv.ParseInt(ex.Labels["acme-expiry"], 10, 64)
-		if err != nil {
-			return nil, time.Now(), fmt.Errorf("invalid expiry format: %s", err.Error())
-		}
-
-		expiry := time.Unix(0, exp)
-
-		glog.Errorf("Expires: %s", expiry.String())
-		if time.Now().Before(expiry) {
-			return nil, time.Now(), fmt.Errorf("existing lock is still valid")
-		}
-
-		err = releaseLock(ex)
-
-		if err != nil {
-			return nil, time.Now(), fmt.Errorf("another instance has deleted the lock: %s", err.Error())
-		}
-
-		expiry, secret = createSecretLock(name, namespace)
-		secret, err = kubeClient.Secrets(namespace).Create(secret)
-
-		if err != nil {
-			return nil, time.Now(), fmt.Errorf("another instance has acquired the lock: %s", err.Error())
-		}
-	}
-
-	return secret, expiry, nil
-}
-
-func releaseLock(lock *api.Secret) error {
-	if _, ok := lock.Labels["acme-expiry"]; !ok {
-		return fmt.Errorf("missing acme-expiry label on lock")
-	}
-
-	requirement, err := labels.NewRequirement("acme-expiry", labels.EqualsOperator, sets.NewString(lock.Labels["acme-expiry"]))
-
-	if err != nil {
-		return err
-	}
-
-	return kubeClient.RESTClient.Delete().
-		Namespace(lock.Namespace).
-		Resource("secrets").
-		Name(lock.Name).
-		LabelsSelectorParam(labels.NewSelector().Add(*requirement)).
-		Do().
-		Error()
-}
-
-func createSecretLock(name string, namespace string) (time.Time, *api.Secret) {
-	expiry := time.Now().Add(time.Second * 30)
-	return expiry, &api.Secret{
+func createSecretLock(name string, namespace string) *api.Secret {
+	return &api.Secret{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name:      name,
+			Name:      fmt.Sprintf("%s-acme", name),
 			Namespace: namespace,
 			Labels: map[string]string{
 				"acme-managed": "true",
 				"acme-lock":    "true",
-				"acme-expiry":  fmt.Sprintf("%d", expiry.UnixNano()),
+				"acme-expiry":  fmt.Sprintf("%d", time.Now().Add(time.Second*30).UnixNano()),
 			},
 		},
 	}

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -184,12 +184,17 @@ func addIngFunc(obj interface{}) {
 
 				if len(errs) > 0 {
 					for _, err := range errs {
-						glog.Errorf("error acquiring locks: %s", err.Error())
+						glog.Errorf("error acquiring lock: %s", err.Error())
 					}
 					continue TLSLoop
 				}
 
-				defer lockSvc.UnlockAll(locks...)
+				defer func() {
+					_, errs := lockSvc.UnlockAll(locks...)
+					for _, err := range errs {
+						glog.Errorf("error releasing lock: %s", err.Error())
+					}
+				}()
 
 				glog.Errorf("acquired all locks for resource: %s", ing.Name)
 

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+var (
+	proxyURL   = flag.String("proxyURL", "", "URL to proxy connections to the apiserver")
+	listenAddr = flag.String("listenAddr", "0.0.0.0:12000", "the address to listen on for incoming http requests")
+
+	kubeClient *client.Client
+)
+
+func main() {
+	flag.Parse()
+
+	if *proxyURL != "" {
+		kubeClient = client.NewOrDie(&client.Config{
+			Host: *proxyURL,
+		})
+	} else {
+		var err error
+		kubeClient, err = client.NewInCluster()
+		if err != nil {
+			glog.Fatalf("Failed to create client: %v.", err)
+		}
+	}
+
+	r := mux.NewRouter()
+
+	r.HandleFunc("/.well-known/acme-challenge/{key}", HandleChallenge)
+
+	glog.Fatalln(http.ListenAndServe(fmt.Sprintf("%s", *listenAddr), r))
+}
+
+func HandleChallenge(w http.ResponseWriter, r *http.Request) {
+	// TODO: Make use of key in request URI
+
+	glog.Errorf("Req from: %s", r.Host)
+	res, err := kubeClient.RESTClient.Get().
+		Namespace("acme").
+		Resource("secrets").
+		Name(fmt.Sprintf("%s-acme", r.Host)).
+		Do().
+		Get()
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	if sec, ok := res.(*api.Secret); !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	} else {
+		if challenge, ok := sec.Data["acme-auth"]; !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		} else {
+			w.Write(challenge)
+		}
+	}
+}

--- a/pkg/acmeimpl/acme.go
+++ b/pkg/acmeimpl/acme.go
@@ -1,0 +1,78 @@
+package acmeimpl
+
+import (
+	"fmt"
+
+	"github.com/xenolf/lego/acme"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type SecretsProvider struct {
+	kubeClient *client.Client
+	namespace  string
+}
+
+func (sp *SecretsProvider) Present(domain, token, keyAuth string) error {
+	secret, err := sp.kubeClient.Secrets(sp.namespace).Get(fmt.Sprintf("%s-acme", domain))
+
+	if err != nil {
+		return err
+	}
+
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data["acme-token"] = []byte(token)
+	secret.Data["acme-auth"] = []byte(keyAuth)
+
+	secret, err = sp.kubeClient.Secrets(sp.namespace).Update(secret)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sp *SecretsProvider) CleanUp(domain, token, keyAuth string) error {
+	return nil
+}
+
+func NewSecretsProvider(kubeClient *client.Client, ns string) (*SecretsProvider, error) {
+	return &SecretsProvider{
+		kubeClient: kubeClient,
+		namespace:  ns,
+	}, nil
+}
+
+type AcmeImpl struct {
+	client     *acme.Client
+	kubeClient *client.Client
+}
+
+func (ai *AcmeImpl) ObtainCertificates(domains ...string) (acme.CertificateResource, map[string]error) {
+	return ai.client.ObtainCertificate(domains, true, nil)
+}
+
+func NewAcmeImpl(kubeClient *client.Client, server string, user User, rsaKeySize acme.KeyType) (*AcmeImpl, error) {
+	client, err := acme.NewClient(server, &user, rsaKeySize)
+
+	if err != nil {
+		return nil, err
+	}
+
+	sp, err := NewSecretsProvider(kubeClient, "acme")
+
+	if err != nil {
+		return nil, err
+	}
+
+	client.ExcludeChallenges([]acme.Challenge{acme.TLSSNI01, acme.DNS01})
+	client.SetChallengeProvider(acme.HTTP01, sp)
+
+	return &AcmeImpl{
+		client:     client,
+		kubeClient: kubeClient,
+	}, nil
+}

--- a/pkg/acmeimpl/acme.go
+++ b/pkg/acmeimpl/acme.go
@@ -47,12 +47,8 @@ func NewSecretsProvider(kubeClient *client.Client, ns string) (*SecretsProvider,
 }
 
 type AcmeImpl struct {
-	client     *acme.Client
+	*acme.Client
 	kubeClient *client.Client
-}
-
-func (ai *AcmeImpl) ObtainCertificates(domains ...string) (acme.CertificateResource, map[string]error) {
-	return ai.client.ObtainCertificate(domains, true, nil)
 }
 
 func NewAcmeImpl(kubeClient *client.Client, server string, user User, rsaKeySize acme.KeyType) (*AcmeImpl, error) {
@@ -72,7 +68,7 @@ func NewAcmeImpl(kubeClient *client.Client, server string, user User, rsaKeySize
 	client.SetChallengeProvider(acme.HTTP01, sp)
 
 	return &AcmeImpl{
-		client:     client,
+		Client:     client,
 		kubeClient: kubeClient,
 	}, nil
 }

--- a/pkg/acmeimpl/user.go
+++ b/pkg/acmeimpl/user.go
@@ -1,0 +1,32 @@
+package acmeimpl
+
+import (
+	"crypto"
+
+	"github.com/xenolf/lego/acme"
+)
+
+// You'll need a user or account type that implements acme.User
+type User struct {
+	Email        string
+	Registration *acme.RegistrationResource
+	key          crypto.PrivateKey
+}
+
+func (u User) GetEmail() string {
+	return u.Email
+}
+func (u User) GetRegistration() *acme.RegistrationResource {
+	return u.Registration
+}
+func (u User) GetPrivateKey() crypto.PrivateKey {
+	return u.key
+}
+
+func NewUser(email string, privKey crypto.PrivateKey, reg *acme.RegistrationResource) User {
+	return User{
+		Email:        email,
+		key:          privKey,
+		Registration: reg,
+	}
+}

--- a/pkg/locking/kube.go
+++ b/pkg/locking/kube.go
@@ -1,0 +1,97 @@
+package locking
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+type KubeProvider struct {
+	kubeClient *client.Client
+}
+
+// Lock will acquire a lock by attempting to create a secret with name `name`
+// in the given namespace. If a lock with the same name already exists, it'll check
+// the locks expiry time and if it's less than the current time, will acquire the lock for
+// itself
+func (kp *KubeProvider) Lock(lock Interface) (Interface, error) {
+	var secret *api.Secret
+	var ok bool
+	var err error
+	if secret, ok = lock.GetObject().(*api.Secret); !ok {
+		return lock, fmt.Errorf("expected lock resource of type *api.Secret")
+	}
+
+	secret, err = kp.kubeClient.Secrets(secret.Namespace).Create(secret)
+
+	if err != nil {
+		ex, err := kp.kubeClient.Secrets(secret.Namespace).Get(secret.Name)
+
+		if err != nil {
+			return nil, fmt.Errorf("secret lock has already been deleted: %s", err.Error())
+		}
+
+		if time.Now().Before(lock.GetExpiry()) {
+			return nil, fmt.Errorf("existing lock is still valid, expires: %s", lock.GetExpiry().String())
+		}
+
+		err = kp.releaseKubeLock(ex)
+
+		if err != nil {
+			return nil, fmt.Errorf("secret lock has already been deleted: %s", err.Error())
+		}
+
+		secret, err = kp.kubeClient.Secrets(secret.Namespace).Create(secret)
+
+		if err != nil {
+			return nil, fmt.Errorf("another instance has acquired the lock: %s", err.Error())
+		}
+	}
+
+	if lock, err = NewKubeLock(secret); err != nil {
+		return nil, fmt.Errorf("invalid response from kube apiserver: %s", err.Error())
+	}
+
+	return lock, nil
+}
+
+func (kp *KubeProvider) Unlock(lock Interface) (Interface, error) {
+	var secret *api.Secret
+	var ok bool
+
+	if secret, ok = lock.GetObject().(*api.Secret); !ok {
+		return lock, fmt.Errorf("expected lock resource of type *api.Secret")
+	}
+
+	return lock, kp.releaseKubeLock(secret)
+}
+
+func (kp *KubeProvider) releaseKubeLock(lock *api.Secret) error {
+	if _, ok := lock.Labels["acme-expiry"]; !ok {
+		return fmt.Errorf("missing acme-expiry label on lock")
+	}
+
+	requirement, err := labels.NewRequirement("acme-expiry", labels.EqualsOperator, sets.NewString(lock.Labels["acme-expiry"]))
+
+	if err != nil {
+		return err
+	}
+
+	return kp.kubeClient.RESTClient.Delete().
+		Namespace(lock.Namespace).
+		Resource("secrets").
+		Name(lock.Name).
+		LabelsSelectorParam(labels.NewSelector().Add(*requirement)).
+		Do().
+		Error()
+}
+
+func NewKubeProvider(kubeClient *client.Client) (*KubeProvider, error) {
+	return &KubeProvider{
+		kubeClient: kubeClient,
+	}, nil
+}

--- a/pkg/locking/kube.go
+++ b/pkg/locking/kube.go
@@ -2,6 +2,7 @@ package locking
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -19,14 +20,14 @@ type KubeProvider struct {
 // the locks expiry time and if it's less than the current time, will acquire the lock for
 // itself
 func (kp *KubeProvider) Lock(lock Interface) (Interface, error) {
-	var secret *api.Secret
+	var secret, newSecret *api.Secret
 	var ok bool
 	var err error
 	if secret, ok = lock.GetObject().(*api.Secret); !ok {
 		return lock, fmt.Errorf("expected lock resource of type *api.Secret")
 	}
 
-	secret, err = kp.kubeClient.Secrets(secret.Namespace).Create(secret)
+	newSecret, err = kp.kubeClient.Secrets(secret.Namespace).Create(secret)
 
 	if err != nil {
 		ex, err := kp.kubeClient.Secrets(secret.Namespace).Get(secret.Name)
@@ -35,8 +36,10 @@ func (kp *KubeProvider) Lock(lock Interface) (Interface, error) {
 			return nil, fmt.Errorf("secret lock has already been deleted: %s", err.Error())
 		}
 
-		if time.Now().Before(lock.GetExpiry()) {
-			return nil, fmt.Errorf("existing lock is still valid, expires: %s", lock.GetExpiry().String())
+		if existingExpiry, err := lockExpiry(ex); err == nil {
+			if time.Now().Before(existingExpiry) {
+				return nil, fmt.Errorf("existing lock is still valid, expires: %s", existingExpiry.String())
+			}
 		}
 
 		err = kp.releaseKubeLock(ex)
@@ -45,14 +48,14 @@ func (kp *KubeProvider) Lock(lock Interface) (Interface, error) {
 			return nil, fmt.Errorf("secret lock has already been deleted: %s", err.Error())
 		}
 
-		secret, err = kp.kubeClient.Secrets(secret.Namespace).Create(secret)
+		newSecret, err = kp.kubeClient.Secrets(secret.Namespace).Create(secret)
 
 		if err != nil {
 			return nil, fmt.Errorf("another instance has acquired the lock: %s", err.Error())
 		}
 	}
 
-	if lock, err = NewKubeLock(secret); err != nil {
+	if lock, err = NewKubeLock(newSecret); err != nil {
 		return nil, fmt.Errorf("invalid response from kube apiserver: %s", err.Error())
 	}
 
@@ -88,6 +91,28 @@ func (kp *KubeProvider) releaseKubeLock(lock *api.Secret) error {
 		LabelsSelectorParam(labels.NewSelector().Add(*requirement)).
 		Do().
 		Error()
+}
+
+func lockExpiry(s *api.Secret) (time.Time, error) {
+	if exp, ok := s.Labels["acme-expiry"]; ok {
+		return expiryToTime(exp)
+	} else {
+		return time.Time{}, fmt.Errorf("no expiry label set on secret")
+	}
+}
+
+func expiryToTime(exp string) (time.Time, error) {
+	i, err := strconv.ParseInt(exp, 10, 64)
+
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Unix(0, i), nil
+}
+
+func timeToExpiry(t time.Time) string {
+	return fmt.Sprintf("%d", t.UnixNano())
 }
 
 func NewKubeProvider(kubeClient *client.Client) (*KubeProvider, error) {

--- a/pkg/locking/kubelock.go
+++ b/pkg/locking/kubelock.go
@@ -1,0 +1,34 @@
+package locking
+
+import (
+	"strconv"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+type KubeLock struct {
+	secret *api.Secret
+	expiry time.Time
+}
+
+func (k *KubeLock) GetObject() interface{} {
+	return k.secret
+}
+
+func (k *KubeLock) GetExpiry() time.Time {
+	return k.expiry
+}
+
+func NewKubeLock(sec *api.Secret) (*KubeLock, error) {
+	t, err := strconv.ParseInt(sec.Labels["acme-expiry"], 10, 64)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubeLock{
+		secret: sec,
+		expiry: time.Unix(0, t),
+	}, nil
+}

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -1,0 +1,88 @@
+package locking
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Locking struct {
+	Provider
+}
+
+type Provider interface {
+	Lock(lock Interface) (Interface, error)
+	Unlock(lock Interface) (Interface, error)
+}
+
+type Interface interface {
+	GetObject() interface{}
+	GetExpiry() time.Time
+}
+
+func (l *Locking) LockAll(locks ...Interface) ([]Interface, []error) {
+	type result struct {
+		lock Interface
+		err  error
+	}
+
+	lockc := make(chan result, len(locks))
+	wg := sync.WaitGroup{}
+	wg.Add(len(locks))
+
+	for _, lock := range locks {
+		go func(lock Interface) {
+			defer wg.Done()
+			lock, err := l.Lock(lock)
+			lockc <- result{lock, err}
+		}(lock)
+	}
+
+	wg.Wait()
+	close(lockc)
+
+	var createdLocks []Interface
+	var errs []error
+	for lock := range lockc {
+		if lock.err != nil {
+			errs = append(errs, lock.err)
+			continue
+		}
+		createdLocks = append(createdLocks, lock.lock)
+	}
+
+	if len(errs) > 0 {
+		_, unlockErrs := l.UnlockAll(createdLocks...)
+
+		errs = append(errs, unlockErrs...)
+
+		return nil, errs
+	}
+
+	return createdLocks, nil
+}
+
+func (l *Locking) UnlockAll(locks ...Interface) ([]Interface, []error) {
+	var res []Interface
+	var errs []error
+
+	for _, lock := range locks {
+		if lock, err := l.Unlock(lock); err != nil {
+			errs = append(errs, err)
+		} else {
+			res = append(res, lock)
+		}
+	}
+
+	return res, nil
+}
+
+func New(provider Provider) (*Locking, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider must not be nil")
+	}
+
+	return &Locking{
+		Provider: provider,
+	}, nil
+}

--- a/pkg/watcher/ingress.go
+++ b/pkg/watcher/ingress.go
@@ -1,0 +1,44 @@
+package watcher
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+func (w *Watcher) WatchIngresses(ctx context.Context, resyncPeriod time.Duration, c ChangeFuncs) {
+	ingHandlers := framework.ResourceEventHandlerFuncs{
+		AddFunc:    c.AddFunc,
+		DeleteFunc: c.DeleteFunc,
+		UpdateFunc: c.UpdateFunc,
+	}
+
+	_, ctrl := framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc:  ingressListFunc(w.kubeClient, w.namespace),
+			WatchFunc: ingressWatchFunc(w.kubeClient, w.namespace),
+		},
+		&extensions.Ingress{}, resyncPeriod, ingHandlers)
+
+	ctrl.Run(ctx.Done())
+}
+
+func ingressListFunc(c *client.Client, ns string) func(api.ListOptions) (runtime.Object, error) {
+	return func(opts api.ListOptions) (runtime.Object, error) {
+		return c.Extensions().Ingress(ns).List(opts)
+	}
+}
+
+func ingressWatchFunc(c *client.Client, ns string) func(options api.ListOptions) (watch.Interface, error) {
+	return func(options api.ListOptions) (watch.Interface, error) {
+		return c.Extensions().Ingress(ns).Watch(options)
+	}
+}

--- a/pkg/watcher/type.go
+++ b/pkg/watcher/type.go
@@ -1,0 +1,16 @@
+package watcher
+
+import (
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type Watcher struct {
+	kubeClient *client.Client
+	namespace  string
+}
+
+type ChangeFuncs struct {
+	AddFunc    func(interface{})
+	DeleteFunc func(interface{})
+	UpdateFunc func(interface{}, interface{})
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,9 @@
+package watcher
+
+import client "k8s.io/kubernetes/pkg/client/unversioned"
+
+func New(client *client.Client, namespace string) (*Watcher, error) {
+	return &Watcher{
+		kubeClient: client,
+	}, nil
+}


### PR DESCRIPTION
- [x] Move locking code into separate package
- [x] Support for renewing certificates automatically
- [ ] Using the key provided on the HTTP request as a query parameter when querying secrets
- [x] Stopping if existing certificates are acme managed & valid
- [x] Storing retrieved certificates back in Kubernetes
