### PR TITLE
allow pushing to custom docker repo from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ go: 1.6
 services: docker
 
 install:
-    - true
+    - if [ ! -d $GOPATH/src/github.com/munnerz ]; then mkdir -p $GOPATH/src/github.com/munnerz; fi
+    - if [ "$TRAVIS_REPO_SLUG" != "munnerz/kube-acme" ]; then ln -s $GOPATH/src/github.com/$TRAVIS_REPO_SLUG $GOPATH/src/github.com/munnerz/kube-acme; fi
 
 script:
     - CGO_ENABLED=0 go build -a -installsuffix cgo github.com/munnerz/kube-acme
 
 after_success:
-    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then docker build -t munnerz/kube-acme:latest .; fi
+    - if [ -z "$DOCKER_IMAGE" ]; then DOCKER_IMAGE='munnerz/kube-acme'; fi
+    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then docker build -t $DOCKER_IMAGE:latest .; fi
     - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"; fi
-    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then docker push munnerz/kube-acme:latest; fi
+    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then docker push $DOCKER_IMAGE:latest; fi


### PR DESCRIPTION
support for master builds with push to different docker image using DockerImage variable. Will push to munnerz/kube-acme by default if not specified for backward compatibility.
